### PR TITLE
fix: add --client-id and --allow-no-subscriptions to az login

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -30,6 +30,8 @@ locals {
 
     # key_vault settings
     key_vault_name = var.worker_keyvault_name != "" && var.worker_keyvault_rg_name != "" ? data.azurerm_key_vault.worker[0].name : ""
+
+    boundary_bootstrap_azure_client_id = azurerm_user_assigned_identity.boundary.client_id
   }
 }
 

--- a/templates/boundary_custom_data.sh.tpl
+++ b/templates/boundary_custom_data.sh.tpl
@@ -16,6 +16,7 @@ BOUNDARY_VERSION="${boundary_version}"
 VERSION=$BOUNDARY_VERSION
 REQUIRED_PACKAGES="jq unzip"
 ADDITIONAL_PACKAGES="${additional_package_names}"
+BOUNDARY_BOOTSTRAP_AZURE_CLIENT_ID="${boundary_bootstrap_azure_client_id}"
 
 function log {
   local level="$1"
@@ -354,8 +355,8 @@ function main {
     az cloud set --name AzureUSGovernment
   fi
 
-  log "INFO" "Running 'az login'."
-  az login --identity --allow-no-subscriptions
+  log "INFO" "Running 'az login --identity --client-id' for client ID '$BOUNDARY_BOOTSTRAP_AZURE_CLIENT_ID'."
+  az login --identity --client-id "$BOUNDARY_BOOTSTRAP_AZURE_CLIENT_ID" --allow-no-subscriptions
 
   generate_boundary_config
   template_boundary_systemd


### PR DESCRIPTION
## Summary

Pass the managed identity client ID explicitly to `az login` and append `--allow-no-subscriptions` to tolerate identities with no subscription associations.

This aligns with the fix already applied in `terraform-azurerm-terraform-enterprise-hvd`.

## Changes

- `compute.tf`: Added `boundary_bootstrap_azure_client_id = azurerm_user_assigned_identity.boundary.client_id` to `local.custom_data_args`
- Template: Added `BOUNDARY_BOOTSTRAP_AZURE_CLIENT_ID` variable declaration
- Template: Updated `az login` to `az login --identity --client-id "$BOUNDARY_BOOTSTRAP_AZURE_CLIENT_ID" --allow-no-subscriptions`

## Why

Explicitly specifying `--client-id` ensures the correct managed identity is used when multiple identities are attached to a VM. The `--allow-no-subscriptions` flag prevents login failures when the identity has no subscription-level RBAC assignments (common for Key Vault-only access patterns).